### PR TITLE
Drop EOL Python

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,8 +1,9 @@
 repos:
   - repo: https://github.com/asottile/pyupgrade
-    rev: v1.19.0
+    rev: v2.31.0
     hooks:
       - id: pyupgrade
+        args: [--py37-plus]
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.2.3

--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,6 @@ if __name__ == '__main__':
                 'License :: OSI Approved :: MIT License',
                 'Natural Language :: English',
                 'Programming Language :: Python',
-                'Programming Language :: Python :: 3.5',
-                'Programming Language :: Python :: 3.6',
                 'Programming Language :: Python :: 3.7',
                 'Programming Language :: Python :: 3.8',
             ],
@@ -46,5 +44,5 @@ if __name__ == '__main__':
                 'Django',
                 'graphviz',
             ],
-            python_requires='>=3.5',
+            python_requires='>=3.7',
     )

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ _project_url = 'https://github.com/hahey/django-migration-vis'
 
 def _get_long_description():
     readme_rst = os.path.join(os.path.dirname(__file__), 'README.rst')
-    with open(readme_rst, 'r') as f:
+    with open(readme_rst) as f:
         return f.read()
 
 


### PR DESCRIPTION
This PR
* Removes Python 3.5 and 3.6 from list of supported Python versions (EOL)
* Upgrades pyupgrade version in pre-commit config
* Updates the repo with pyupgrade, for Python 3.7